### PR TITLE
Bump python support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.11', '3.12']
+        python: ['3.12', '3.13']
     env:
       DEBUG_ACCESS_KEY: ${{ secrets.DEBUG_ACCESS_KEY }}
     steps:


### PR DESCRIPTION
- add python3.13 CI
- drop python3.11 CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automation workflow to test and build using Python versions 3.12 and 3.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->